### PR TITLE
Hotfix: missing * to unpack arguments

### DIFF
--- a/tools/owlfft.py
+++ b/tools/owlfft.py
@@ -22,10 +22,10 @@ from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg, NavigationTool
 from matplotlib.figure import Figure
 from matplotlib.widgets import Cursor
 
-__version__ = "0.0.4"
+__version__ = "0.0.5"
 
 NavigationToolbar2QT.toolitems = (('Save', 'Save the figure', 'filesave', 'save_figure'),)
-NavigationToolbar2QT.set_message = lambda _: ""
+NavigationToolbar2QT.set_message = lambda *_: ""
 
 
 class FFTCalculator():


### PR DESCRIPTION
**Description**
When the window is opened from the commandline and thw mouse passes over a figure, unpacking lambda arguments prevents from throwing exceptions

**Changelog**
- Added missing * to unpack arguments
